### PR TITLE
Add test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: CI
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ruby just zsh ksh fish dash
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install ruby just zsh ksh fish dash
+      - name: Run tests
+        run: just test

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,4 @@
+set shell := ['bash', '-euo', 'pipefail', '-c']
+
+test:
+    ruby test/import_env_test.rb

--- a/test/import_env_test.rb
+++ b/test/import_env_test.rb
@@ -1,0 +1,52 @@
+require 'minitest/autorun'
+require 'open3'
+require 'tempfile'
+
+SHELLS = %w[sh bash zsh dash ksh fish]
+IGNORED = /^(export _=|export LOGNAME=|export OLDPWD=|export A__z=|export SHLVL=|export USER=)/
+
+def run_script(shell, body, env = {})
+  interpreter = `which #{shell}`.strip
+  file = Tempfile.new('script')
+  file.write("#!#{interpreter}\n#{body}\n")
+  file.close
+  File.chmod(0755, file.path)
+  output, status = Open3.capture2(env, 'ruby', 'bin/import-env', file.path)
+  file.unlink
+  [output, status.exitstatus]
+end
+
+class ImportEnvTest < Minitest::Test
+  def filtered(output)
+    output.lines.reject { |l| l =~ IGNORED }
+  end
+
+  SHELLS.each do |sh|
+    define_method("test_no_changes_#{sh}") do
+      out, code = run_script(sh, '')
+      assert_equal 0, code
+      assert_empty filtered(out), out
+    end
+
+    define_method("test_added_#{sh}") do
+      out, code = run_script(sh, 'export NEWVAR=hello')
+      assert_equal 0, code
+      assert_includes out.lines, "export NEWVAR='hello'\n"
+    end
+
+    define_method("test_modified_#{sh}") do
+      env = { 'TESTVAR' => 'orig' }
+      out, code = run_script(sh, 'export TESTVAR=$TESTVAR:/extra', env)
+      assert_equal 0, code
+      assert_includes out.lines, "export TESTVAR='orig:/extra'\n"
+    end
+
+    define_method("test_deleted_#{sh}") do
+      env = { 'DELVAR' => 'gone' }
+      cmd = sh == 'fish' ? 'set -e DELVAR' : 'unset DELVAR'
+      out, code = run_script(sh, cmd, env)
+      assert_equal 0, code
+      assert_includes out.lines, "unset DELVAR\n"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a basic test suite for `import-env`
- configure `just` to run the tests
- run test suite in GitHub Actions on Linux and macOS

## Testing
- `just test`